### PR TITLE
Add Array Benchmark

### DIFF
--- a/Program.fs
+++ b/Program.fs
@@ -38,6 +38,15 @@ type Benchmarks () =
             1_000_000
         |]
 
+
+    // An array of different Arrays for each size in Size
+    let arrays =
+        sizeToCount
+        |> Array.map (fun count ->
+            [|1 .. count - 1|]
+            |> Array.map (fun i -> string i, ValueWrapper 0.0)
+            )
+
     // An array of different Maps for each size in Size
     let maps =
         sizeToCount
@@ -66,8 +75,7 @@ type Benchmarks () =
             )
 
 
-    [<Params(Size.``10``, Size.``100``, Size.``1_000``, Size.``10_000``,
-             Size.``100_000``, Size.``1_000_000``)>]
+    [<Params(Size.``10``)>]//, Size.``100``, Size.``1_000``, Size.``10_000``, Size.``100_000``, Size.``1_000_000``)>]
     member val Size = Size.``10`` with get, set
 
 
@@ -86,6 +94,20 @@ type Benchmarks () =
             map <- map.Add (key, newValue) // Do a minimal amount of work
 
         map
+
+    [<Benchmark>]
+    member b.Array () =
+        // We using mutation to ensure the compiler doesn't eliminate unnecessary work
+        let mutable array = arrays[int b.Size]
+        let keys = keysForSize[int b.Size]
+
+        for i = 0 to keys.Length - 1 do
+            let key = keys[i]
+            let index =  array |> Array.findIndex (fun (k,_) -> k = key)
+            let _, v = array.[index]
+            v.Value <- v.Value + 1.0
+        array
+
 
 
     [<Benchmark>]


### PR DESCRIPTION
I was curious to see how Dictionary compared to Array at small sizes. This add a benchmark using an array with a linear look up to find a ValueWrapper.  I limited it to size 10 so the run would not take too long. 

Based on the results below it looks like Array is competitive up to sizes of about 10. I tried to add a size of 5 but was not able to. 



```
|                 Method | Size |     Mean |    Error |   StdDev |
|----------------------- |----- |---------:|---------:|---------:|
|                    Map |   10 | 965.0 ns | 10.70 ns | 10.01 ns |
|                  Array |   10 | 295.2 ns |  5.19 ns |  4.85 ns |
|             Dictionary |   10 | 324.6 ns |  4.51 ns |  4.22 ns |
| ValueWrappedDictionary |   10 | 124.2 ns |  1.60 ns |  1.49 ns |
|       DictionaryGetRef |   10 | 141.0 ns |  2.89 ns |  2.84 ns |
```